### PR TITLE
Start over

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,57 @@
 # Archaic cas names
 
-Many CRISPR-associated genes have been renamed, sometimes more than once. Sequences databases often retain an archaic name, making searching for particular genes tricky. This repo exists to keep track of the various alternatives for each cas gene. In cases where there is no consensus in the community, this database will prefer the more consistent naming scheme. 
+Many CRISPR-associated genes have been renamed, sometimes more than once. Sequences databases often retain an archaic name, making searching for particular genes tricky. This repo exists to keep track of the various alternatives for each *cas* gene. In cases where there is no consensus in the community, this database will prefer the more consistent naming scheme. 
 
 ### Contributing
 
-Please open an issue or submit a pull request (with references) if you feel there should be any additions or modifications to this list. You can also just email me at [jim@rybarski.com](mailto:jim@rybarski.com).
+Please open an issue or submit a pull request (with references) if you feel there should be any additions or modifications to this list. You can also just email [jim@rybarski.com](mailto:jim@rybarski.com).
 
 ### Names
 
-| Current name | Archaic names | References | 
-| --- | --- | --- | 
-| cas1 | - | 1 |  
-| cas2 | - | 1 | 
-| cas3 | - | 1 |
-| cas4 | csa1 | 1 |
-| cas5 | casD, cas5a, cas5d, cas5e, cas5h, cas5p, cas5t, cmx5, csc1, csy2, csf3, csm4, csx10, cmr3 | 1, 18 |
-| cas6 | cmx6 | 1 | 
-| cas6e | casE, cse3 | 1, 13 |
-| cas6f | csy4 | 1, 14 |
-| cas7 | casC, csa2, csd2, cse4, csh2, csp1, cst2, csm3, cmr4, csc2, csy3, csf2, csm5, cmr1, cmr6 | 1, 17, 18 | 
-| cas8 | csf1 | 18 | 
-| cas8a1 | cmx1, cst1, csx8, csx13, CXXC-CXXC | 1 |
-| cas8a2 | csa4, csx9 | 1 |
-| cas8b | csh1, TM1802 | 1 |
-| cas8c | csd1, csp2 | 1 |
-| cas8e | casA, cse1 | 1, 15 |
-| cas8f | csy1 | 18 |
-| cas9 | csn1, csx12 | 13 | 
-| cas10 | cmr2, csm1, csx1 | 1 |
-| cas10d | csc3 | 1 |
-| cas11 | casB, cse2, csm2, cmr5, csa5 | 1, 15, 16, 18 |
-| cas12a | cpf1 | 4, 6, 10 |
-| cas12b | c2c1 | 3, 6, 10 |
-| cas12c | c2c3 | 5, 10 |
-| cas12d | casY | 5 | 
-| cas12e | casX | 6, 18 |
-| cas12f | cas14 | 6 |
-| cas12g | - | | 
-| cas12h | - | |
-| cas12i | - | |
-| cas12j | casΦ | 9 |
-| cas12k | c2c5, Type V-U5 | 11 | 
-| cas12l | casπ | 7, 8 |
-| cas12m | - | |
-| cas13a | c2c2 | 2, 10 |
-| cas13b | c2c4, c2c6 | 10, 12 |
-| cas13c | c2c7 | 10 |
-| cas13d | - | | 
+Each name is given with the reference where it was first used.
+
+| Current name | Previous name(s) |
+| --- | --- |
+| cas1 [1] | - |
+| cas2 [1] | - |
+| cas3 [1] | - |
+| cas4 [1] | csa1 [?] |
+| cas5 | casD, cas5a, cas5d, cas5e, cas5h, cas5p, cas5t, cmx5, csc1, csy2, csf3, csm4, csx10, cmr3 |
+| cas6 | cmx6 |
+| cas6e | casE, cse3 |
+| cas6f | csy4 |
+| cas7 | casC, csa2, csd2, cse4, csh2, csp1, cst2, csm3, cmr4, csc2, csy3, csf2, csm5, cmr1, cmr6 |
+| cas8 | csf1 |
+| cas8a1 | cmx1, cst1, csx8, csx13, CXXC-CXXC |
+| cas8a2 | csa4, csx9 |
+| cas8b | csh1, TM1802 |
+| cas8c | csd1, csp2 |
+| cas8e | casA, cse1 |
+| cas8f | csy1 | 
+| cas9 | csn1, csx12 | 
+| cas10 | cmr2, csm1, csx1 |
+| cas10d | csc3 | 
+| cas11 | casB, cse2, csm2, cmr5, csa5 | 
+| cas12a | cpf1 | 
+| cas12b | c2c1 |
+| cas12c | c2c3 |
+| cas12d | casY |
+| cas12e | casX |
+| cas12f | cas14 |
+| cas12g | - |
+| cas12h | - |
+| cas12i | - |
+| cas12j | casΦ |
+| cas12k | c2c5, Type V-U5 |
+| cas12l | casπ |
+| cas12m | - |
+| cas13a | c2c2 |
+| cas13b | c2c4, c2c6 |
+| cas13c | c2c7 |
+| cas13d | - |
  
 ### References
 
-| \# | Reference | URL |
+| \# | Reference | DOI |
 | --- | --- | --- |
-| 1 | Makarova et al. *Evolution and classification of the CRISPR-Cas systems.* Nat. Rev. Microbiol. (2011) | [link](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3380444/) |
-| 2 | Gootenberg and Abudayyeh et al. *Nucleic acid detection withCRISPR-Cas13a/C2c2* Science (2017) | [link](https://www.science.org/doi/10.1126/science.aam9321) |
-| 3 | Strecker et al. *Engineering of CRISPR-Cas12b for human genome editing* Nat. Comm. (2019) | [link](https://www.nature.com/articles/s41467-018-08224-4) |
-| 4 | Swarts and Jinek. *Cas9 versus Cas12a/Cpf1: Structure–function comparisons and implications for genome editing* WIREs RNA (2018) | [link](https://wires.onlinelibrary.wiley.com/doi/full/10.1002/wrna.1481) |
-| 5 | Harrington and Ma et al. *A scoutRNA Is Required for Some Type V CRISPR-Cas Systems* Mol. Cell (2020) | [link](https://www.sciencedirect.com/science/article/pii/S109727652030424X) |
-| 6 | Anzalone and Koblan et al. *Genome editing with CRISPR–Cas nucleases, base editors, transposases and prime editors* Nat. Biotech. (2020) | [link](https://www.nature.com/articles/s41587-020-0561-9) |
-| 7 | Urbaitis, Gasiunas, and Young et al. *A new family of CRISPR-type V nucleases with C-rich PAM recognition* EMBO Reports (2022) | [link](https://www.embopress.org/doi/full/10.15252/embr.202255481) |
-| 8 | Sun et al. *The compact Casπ (Cas12l) ‘bracelet’ provides a unique structural platform for DNA manipulation.* Cell Res (2023) | [link](https://www.nature.com/articles/s41422-022-00771-2) | 
-| 9 | Pausch and Soczek et al. *DNA interference states of the hypercompact CRISPR–CasΦ effector*  Nat. Struct. Mol. Biol. (2021) | [link](https://www.nature.com/articles/s41594-021-00632-3) |
-| 10 | Shmakov et al. *Diversity and evolution of class 2 CRISPR–Cas systems* Nat. Rev. Microbiol. (2017) | [link](https://www.nature.com/articles/nrmicro.2016.184) |
-| 11 | Faure et al. *CRISPR–Cas in mobile genetic elements: counter-defence and beyond* Nat. Rev. Microbiol. (2019) | [link](https://www.nature.com/articles/s41579-019-0204-7) | 
-| 12 | Tang and Fu *Class 2 CRISPR/Cas: an expanding biotechnology toolbox for and beyond genome editing* Cell & Biosci. (2018) | [link](https://cellandbioscience.biomedcentral.com/articles/10.1186/s13578-018-0255-x) |
-| 13 | Carte et al. *The three major types of CRISPR-Cas systems function independently in CRISPR RNA biogenesis in Streptococcus thermophilus* Mol. Microbio. (2014) | [link](https://onlinelibrary.wiley.com/doi/full/10.1111/mmi.12644) |
-| 14 | Dwarakanath et al. *Interference activity of a minimal Type I CRISPR–Cas system from Shewanella putrefaciens* NAR (2015) | [link](https://academic.oup.com/nar/article/43/18/8913/2414506) |
-| 15 | Hille et al. *The Biology of CRISPR-Cas: Backward and Forward* Cell (2018) | [link](https://www.sciencedirect.com/science/article/pii/S0092867417313831)
-| 16 | Heidrich and Vogel *Same same but different: new structural insight into CRISPR-Cas complexes* Mol. Cell (2013) | [link](https://pubmed.ncbi.nlm.nih.gov/24119398/)
-| 17 | Kato and Zhou et al. *Structure and engineering of the type III-E CRISPR-Cas7-11 effector complex* Cell (2022) | [link](https://www.sciencedirect.com/science/article/pii/S0092867422005815) |
-| 18 | Koonin and Makarova *Mobile Genetic Elements and Evolution of CRISPR-Cas Systems: All the Way There and Back* Genome Biol. Evol. (2017) | [link](https://pubmed.ncbi.nlm.nih.gov/28985291/) |
+| 1 | Jansen et al. *Identification of genes that are associated with DNArepeats in prokaryotes.* Mol. Microbio. (2002) | [10.1046/j.1365-2958.2002.02839.x](https://doi.org/10.1046/j.1365-2958.2002.02839.x) |

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Each name is given with the reference where it was first used.
 
 | \# | Reference | DOI |
 | --- | --- | --- |
-| 1 | Jansen et al. *Identification of genes that are associated with DNArepeats in prokaryotes.* Mol. Microbio. (2002) | [10.1046/j.1365-2958.2002.02839.x](https://doi.org/10.1046/j.1365-2958.2002.02839.x) |
+| 1 | Jansen et al. *Identification of genes that are associated with DNA repeats in prokaryotes.* Mol. Microbio. (2002) | [10.1046/j.1365-2958.2002.02839.x](https://doi.org/10.1046/j.1365-2958.2002.02839.x) |


### PR DESCRIPTION
We want to cite the first reference where a term was used, which the old database didn't do. I've started over from scratch to avoid accidentally mixing references between the two versions.

Additionally, I've added the reference that coined cas1-4, and changed the reference to the DOI in order to make this a more robust resource.